### PR TITLE
Add AISO, Hitoshi (yui666a) as copyright holder to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2022 Kazuya Iijima, yui666a
+Copyright (c) 2026 AISO, Hitoshi (yui666a)
+Copyright (c) 2022 Kazuya Iijima
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Add `Copyright (c) 2026 AISO, Hitoshi (yui666a)` to the LICENSE file as a copyright holder

## Changes
- Updated `LICENSE` to include AISO, Hitoshi (yui666a) alongside the existing copyright holder

🤖 Generated with [Claude Code](https://claude.com/claude-code)