### PR TITLE
feat: コメント流速を一定速度（px/sec）に変更

### DIFF
--- a/src/background/injectComment.ts
+++ b/src/background/injectComment.ts
@@ -91,12 +91,17 @@ export const injectComment = async (message: string, author?: string) => {
   comment.style["whiteSpace"] = "nowrap";
   comment.style["lineHeight"] = "initial";
 
+  // 一定速度 (px/sec) で流す。移動距離 = 画面幅 + テキスト幅
+  const SPEED_PX_PER_SEC = 400;
+  const travelDistance = screenWidth + comment.offsetWidth;
+  const duration = (travelDistance / SPEED_PX_PER_SEC) * 1000;
+
   const streamCommentUI = comment.animate(
     {
       left: `${-comment.offsetWidth}px`,
     },
     {
-      duration: 6000,
+      duration,
       easing: "linear",
     }
   );


### PR DESCRIPTION
## Summary

- アニメーション duration を6秒固定から、移動距離ベースの一定速度（400px/sec）に変更
- `duration = (screenWidth + textWidth) / 400 * 1000` で算出
- 短文でも長文でも同じ速さで流れ、読みやすさが向上

## Test plan

- [x] 短文（1〜3文字）と長文（20文字以上）を送信し、同じ速度で流れることを確認
- [x] フォントサイズ変更後も速度が一定であることを確認
- [x] Google Slides フルスクリーンモードでも正常に動作することを確認
- [x] コメントが画面外に完全に消えた後に DOM から削除されることを確認

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)