### PR TITLE
feat: noExplicitAny・noNonNullAssertion ルール追加と as キャスト除去

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -15,7 +15,13 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true
+			"recommended": true,
+			"suspicious": {
+				"noExplicitAny": "error"
+			},
+			"style": {
+				"noNonNullAssertion": "error"
+			}
 		}
 	},
 	"javascript": {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -37,8 +37,8 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
 							target: { tabId: tabs[0].id },
 							func: injectComment,
 							args: [
-								res[StorageKeys.Comment] as string,
-								(res[StorageKeys.CommentAuthor] as string) || "",
+								String(res[StorageKeys.Comment]),
+								String(res[StorageKeys.CommentAuthor] ?? ""),
 							],
 						});
 					});


### PR DESCRIPTION
## Summary

Closes #30

- `biome.json` に `suspicious/noExplicitAny` と `style/noNonNullAssertion` を error レベルで追加
- `src/background/index.ts` の `as string` キャストを `String()` に置き換え

## Test plan

- [x] `pnpm run check` がエラー 0 件で通ること
- [x] `pnpm run build` が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)