### PR TITLE
refactor: background メッセージルーティング分解とレース修正

### DIFF
--- a/src/background/handlers/comment.ts
+++ b/src/background/handlers/comment.ts
@@ -1,0 +1,47 @@
+import { STORAGE_KEYS } from "../../shared/storageKeys";
+import { injectComment } from "../injectComment";
+
+export const setComment = async (value: string, author?: string) => {
+	const data: Record<string, string | number> = {
+		[STORAGE_KEYS.Comment]: value,
+		[STORAGE_KEYS.CommentId]: Date.now(),
+	};
+	if (author) data[STORAGE_KEYS.CommentAuthor] = author;
+	await chrome.storage.local.set(data);
+};
+
+// 指定された commentId と一致する場合のみコメントを削除する（連続投稿時のレース防止）
+export const deleteCommentIfMatches = async (commentId: number) => {
+	const stored = await chrome.storage.local.get([STORAGE_KEYS.CommentId]);
+	if (stored[STORAGE_KEYS.CommentId] !== commentId) return;
+
+	await chrome.storage.local.remove([
+		STORAGE_KEYS.Comment,
+		STORAGE_KEYS.CommentAuthor,
+		STORAGE_KEYS.CommentId,
+	]);
+};
+
+export const flushCommentToFocusedTab = async () => {
+	const stored = await chrome.storage.local.get([
+		STORAGE_KEYS.Comment,
+		STORAGE_KEYS.CommentAuthor,
+		STORAGE_KEYS.CommentId,
+	]);
+
+	const comment = stored[STORAGE_KEYS.Comment];
+	if (!comment) return;
+
+	const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+	if (!tab?.id) return;
+
+	await chrome.scripting.executeScript({
+		target: { tabId: tab.id },
+		func: injectComment,
+		args: [
+			String(comment),
+			String(stored[STORAGE_KEYS.CommentAuthor] ?? ""),
+			Number(stored[STORAGE_KEYS.CommentId] ?? 0),
+		],
+	});
+};

--- a/src/background/handlers/settings.ts
+++ b/src/background/handlers/settings.ts
@@ -1,0 +1,30 @@
+import { STORAGE_KEYS } from "../../shared/storageKeys";
+
+export const getColor = async (): Promise<string | undefined> => {
+	const stored = await chrome.storage.local.get([STORAGE_KEYS.Color]);
+	const value = stored[STORAGE_KEYS.Color];
+	return typeof value === "string" ? value : undefined;
+};
+
+export const setColor = (value: string) =>
+	chrome.storage.local.set({ [STORAGE_KEYS.Color]: value });
+
+export const getFontSize = async (): Promise<string | undefined> => {
+	const stored = await chrome.storage.local.get([STORAGE_KEYS.FontSize]);
+	const value = stored[STORAGE_KEYS.FontSize];
+	return typeof value === "string" ? value : undefined;
+};
+
+export const setFontSize = (value: string) =>
+	chrome.storage.local.set({ [STORAGE_KEYS.FontSize]: value });
+
+export const getIsEnabledStreaming = async (): Promise<boolean | undefined> => {
+	const stored = await chrome.storage.local.get([
+		STORAGE_KEYS.IsEnabledStreaming,
+	]);
+	const value = stored[STORAGE_KEYS.IsEnabledStreaming];
+	return typeof value === "boolean" ? value : undefined;
+};
+
+export const setIsEnabledStreaming = (value: boolean) =>
+	chrome.storage.local.set({ [STORAGE_KEYS.IsEnabledStreaming]: value });

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,82 +1,62 @@
-import { injectComment } from "./injectComment";
+import type { MessageRequest } from "../shared/messages";
+import {
+	deleteCommentIfMatches,
+	flushCommentToFocusedTab,
+	setComment,
+} from "./handlers/comment";
+import {
+	getColor,
+	getFontSize,
+	getIsEnabledStreaming,
+	setColor,
+	setFontSize,
+	setIsEnabledStreaming,
+} from "./handlers/settings";
 
-const StorageKeys = {
-	Comment: "comment",
-	CommentAuthor: "commentAuthor",
-	Color: "color",
-	FontSize: "fontSize",
-	IsEnabledStreaming: "isEnabledStreaming",
-} as const;
+chrome.runtime.onMessage.addListener(
+	(request: MessageRequest, _sender, sendResponse) => {
+		switch (request.method) {
+			case "setComment":
+				setComment(request.value, request.author);
+				return false;
 
-chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
-	switch (request.method) {
-		case "setComment": {
-			const commentData: Record<string, string> = {
-				comment: request.value,
-			};
-			if (request.author) {
-				commentData.commentAuthor = request.author;
+			case "deleteComment":
+				deleteCommentIfMatches(request.commentId);
+				return false;
+
+			case "flushComment":
+				flushCommentToFocusedTab();
+				return false;
+
+			case "setColor":
+				setColor(request.value);
+				return false;
+
+			case "getColor":
+				getColor().then(sendResponse);
+				return true;
+
+			case "setFontSize":
+				setFontSize(request.value);
+				return false;
+
+			case "getFontSize":
+				getFontSize().then(sendResponse);
+				return true;
+
+			case "setIsEnabledStreaming":
+				setIsEnabledStreaming(request.value);
+				return false;
+
+			case "getIsEnabledStreaming":
+				getIsEnabledStreaming().then(sendResponse);
+				return true;
+
+			default: {
+				const _exhaustive: never = request;
+				console.warn("Unknown message request:", _exhaustive);
+				return false;
 			}
-			chrome.storage.local.set(commentData);
-			return true;
 		}
-		case "deleteComment":
-			chrome.storage.local.remove([
-				StorageKeys.Comment,
-				StorageKeys.CommentAuthor,
-			]);
-			return true;
-		case "injectCommentToFocusedTab":
-			chrome.storage.local
-				.get([StorageKeys.Comment, StorageKeys.CommentAuthor])
-				.then((res) => {
-					chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-						if (!tabs[0]?.id || !res[StorageKeys.Comment]) return;
-
-						chrome.scripting.executeScript({
-							target: { tabId: tabs[0].id },
-							func: injectComment,
-							args: [
-								String(res[StorageKeys.Comment]),
-								String(res[StorageKeys.CommentAuthor] ?? ""),
-							],
-						});
-					});
-				});
-			return true;
-		case "setColor":
-			chrome.storage.local.set({
-				color: request.value,
-			});
-			return true;
-		case "getColor":
-			chrome.storage.local.get([StorageKeys.Color]).then((res) => {
-				sendResponse(res[StorageKeys.Color]);
-			});
-			return true;
-		case "setFontSize":
-			chrome.storage.local.set({
-				fontSize: request.value,
-			});
-			return true;
-		case "getFontSize":
-			chrome.storage.local.get([StorageKeys.FontSize]).then((res) => {
-				sendResponse(res[StorageKeys.FontSize]);
-			});
-			return true;
-		case "setIsEnabledStreaming":
-			chrome.storage.local.set({
-				isEnabledStreaming: request.value,
-			});
-			return true;
-		case "getIsEnabledStreaming":
-			chrome.storage.local.get([StorageKeys.IsEnabledStreaming]).then((res) => {
-				if (typeof res[StorageKeys.IsEnabledStreaming] !== "boolean") return;
-				sendResponse(res[StorageKeys.IsEnabledStreaming]);
-			});
-			return true;
-		default:
-			console.log("no method");
-			return true;
-	}
-});
+	},
+);

--- a/src/background/injectComment.ts
+++ b/src/background/injectComment.ts
@@ -1,4 +1,8 @@
-export const injectComment = async (message: string, author?: string) => {
+export const injectComment = async (
+	message: string,
+	author: string,
+	commentId: number,
+) => {
 	const screenHeight = window.innerHeight;
 	const screenWidth = window.innerWidth;
 
@@ -138,9 +142,10 @@ export const injectComment = async (message: string, author?: string) => {
 		},
 	);
 
-	// NOTE: delete data in localStorage so that same comments can be sent in a row
+	// NOTE: 表示中の commentId と一致する場合のみ削除する。連続投稿時に
+	// 新しいコメントを誤って消さないための安全策。
 	streamCommentUI.ready.then(() =>
-		chrome.runtime.sendMessage({ method: "deleteComment" }),
+		chrome.runtime.sendMessage({ method: "deleteComment", commentId }),
 	);
 
 	streamCommentUI.onfinish = () => {

--- a/src/contentScripts/streamComment.ts
+++ b/src/contentScripts/streamComment.ts
@@ -1,5 +1,6 @@
-const streamComment = () => {
-	chrome.runtime.sendMessage({ method: "injectCommentToFocusedTab" });
-};
+import { STORAGE_KEYS } from "../shared/storageKeys";
 
-chrome.storage.onChanged.addListener(streamComment);
+chrome.storage.onChanged.addListener((changes) => {
+	if (!changes[STORAGE_KEYS.Comment]?.newValue) return;
+	chrome.runtime.sendMessage({ method: "flushComment" });
+});

--- a/src/contentScripts/utils/decodeHTMLSpecialWord.ts
+++ b/src/contentScripts/utils/decodeHTMLSpecialWord.ts
@@ -5,5 +5,5 @@ export const decodeHTMLSpecialWord = (str: string): string => {
 		.replace(/&gt;/g, ">")
 		.replace(/&quot;/g, '"')
 		.replace(/&#x27;/g, "'")
-		.replace(/&#x60/g, "`");
+		.replace(/&#x60;/g, "`");
 };

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -1,0 +1,41 @@
+export type SetCommentRequest = {
+	method: "setComment";
+	value: string;
+	author?: string;
+};
+
+export type DeleteCommentRequest = {
+	method: "deleteComment";
+	commentId: number;
+};
+
+export type FlushCommentRequest = {
+	method: "flushComment";
+};
+
+export type SetColorRequest = { method: "setColor"; value: string };
+export type GetColorRequest = { method: "getColor" };
+
+export type SetFontSizeRequest = { method: "setFontSize"; value: string };
+export type GetFontSizeRequest = { method: "getFontSize" };
+
+export type SetIsEnabledStreamingRequest = {
+	method: "setIsEnabledStreaming";
+	value: boolean;
+};
+export type GetIsEnabledStreamingRequest = {
+	method: "getIsEnabledStreaming";
+};
+
+export type MessageRequest =
+	| SetCommentRequest
+	| DeleteCommentRequest
+	| FlushCommentRequest
+	| SetColorRequest
+	| GetColorRequest
+	| SetFontSizeRequest
+	| GetFontSizeRequest
+	| SetIsEnabledStreamingRequest
+	| GetIsEnabledStreamingRequest;
+
+export type MessageMethod = MessageRequest["method"];

--- a/src/shared/storageKeys.ts
+++ b/src/shared/storageKeys.ts
@@ -1,0 +1,10 @@
+export const STORAGE_KEYS = {
+	Comment: "comment",
+	CommentAuthor: "commentAuthor",
+	CommentId: "commentId",
+	Color: "color",
+	FontSize: "fontSize",
+	IsEnabledStreaming: "isEnabledStreaming",
+} as const;
+
+export type StorageKey = (typeof STORAGE_KEYS)[keyof typeof STORAGE_KEYS];


### PR DESCRIPTION
## Summary
- `background/index.ts` の巨大 switch を `handlers/comment.ts` と `handlers/settings.ts` に責務分割
- `shared/messages.ts` に discriminated union でメッセージ型を集約（型安全化）
- `shared/storageKeys.ts` に storage key を集約
- `streamComment.ts` を `changes.comment` 変更時のみ発火するようガード（color/fontSize 変更で誤発火していた）
- 連続投稿時のレース修正：`commentId` を `Date.now()` で付与し、`deleteComment` は一致時のみ実行
- `decodeHTMLSpecialWord`: `/&#x60/g` → `/&#x60;/g` にセミコロン欠けを修正
- default ケースの握りつぶしを exhaustive check + console.warn に

## 背景（レビュー結果の反映 #1）
レビューで特定した High 優先度項目:
1. handler 分解（テスタビリティ・変更容易性向上）
2. onChanged の無差別発火をガード
3. deleteComment のレース修正
8. `&#x60;` 正規表現のバグ

## Test plan
- [ ] `pnpm check`（Biome）がパスすること
- [ ] `pnpm build` がエラーなく通ること
- [ ] コメント投稿時にコメントが従来どおり流れること
- [ ] 連続投稿（5件連打等）で最後のコメントが消えないこと
- [ ] color 変更・fontSize 変更で inject が走らないこと（従来は走っていた）

🤖 Generated with [Claude Code](https://claude.com/claude-code)