### PR TITLE
refactor: injectComment 分解・extractor factory 化・変数名整理

### DIFF
--- a/src/background/injectComment.ts
+++ b/src/background/injectComment.ts
@@ -1,104 +1,77 @@
+// NOTE: この関数は chrome.scripting.executeScript により対象タブのページコンテキストで実行される。
+//       そのためトップレベル import に依存できず、定数や helper もすべて関数内に閉じ込める必要がある。
 export const injectComment = async (
 	message: string,
 	author: string,
 	commentId: number,
 ) => {
-	const screenHeight = window.innerHeight;
-	const screenWidth = window.innerWidth;
+	// --- 定数 ---
+	const SPEED_PX_PER_SEC = 400;
+	const FOOTER_HEIGHT_PX = 88;
+	const BASE_FONT_SIZE_RATIO = 0.05; // 画面高さに対するフォントサイズ基準
+	const LANE_GAP_RATIO = 0.2; // フォントサイズに対するレーン間隔
+	const DEFAULT_COLOR = "green";
+	const COMMENT_CLASS = "google-meet-comment-flow";
+	const LANE_ATTR = "data-lane";
+	const MAX_Z_INDEX = "2147483647";
+	const FONT_SIZE_COEFFICIENTS: Record<string, number> = {
+		XS: 0.25,
+		S: 0.5,
+		M: 1,
+		L: 2,
+		XL: 4,
+	};
+	const DEFAULT_FONT_SIZE_COEFFICIENT = FONT_SIZE_COEFFICIENTS.L;
 
-	const comment = document.createElement("span");
+	// --- helpers ---
+	// Google Slide の全画面モードでは最大 z-index の overlay が存在するため、
+	// そちらに追加しないとコメントが埋もれる。
+	const resolveTargetNode = (): HTMLElement => {
+		const fullScreenOverlay = document.querySelector<HTMLElement>(
+			"body > div.punch-full-screen-element.punch-full-window-overlay",
+		);
+		return fullScreenOverlay ?? document.body;
+	};
 
-	comment.textContent = message;
+	const resolveFontSizePx = (screenHeightPx: number, key: string): number => {
+		const coefficient =
+			FONT_SIZE_COEFFICIENTS[key] ?? DEFAULT_FONT_SIZE_COEFFICIENT;
+		return screenHeightPx * BASE_FONT_SIZE_RATIO * coefficient;
+	};
 
-	// NOTE: google slide full screen mode element
-	const gSlideContentNode = document.querySelector(
-		"body > div.punch-full-screen-element.punch-full-window-overlay",
-	);
+	type LanePlacement = { topPx: number; laneIndex: number | null };
 
-	/*
-  NOTE: When the focused tab is on google slide full screen mode,
-        target node is the specific div, whose z-index is max value
-        as the same as the value of streamed comments
+	const pickLanePlacement = (
+		fontSizePx: number,
+		availableHeightPx: number,
+		scrollTopPx: number,
+	): LanePlacement => {
+		const laneHeightPx = fontSizePx + fontSizePx * LANE_GAP_RATIO;
+		const laneCount = Math.max(1, Math.floor(availableHeightPx / laneHeightPx));
 
-  SEE: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
-  */
-	const targetNode = gSlideContentNode || document.body;
+		const occupiedLanes = new Set(
+			Array.from(
+				document.querySelectorAll(`.${COMMENT_CLASS}[${LANE_ATTR}]`),
+			).map((el) => Number(el.getAttribute(LANE_ATTR))),
+		);
 
-	targetNode.appendChild(comment);
+		const freeLanes = Array.from({ length: laneCount }, (_, i) => i).filter(
+			(i) => !occupiedLanes.has(i),
+		);
 
-	const storedFontSizeMessage = await chrome.runtime.sendMessage({
-		method: "getFontSize",
-	});
-
-	const letterSizeCoefficient = () => {
-		switch (storedFontSizeMessage) {
-			case "XS":
-				return 0.25;
-			case "S":
-				return 0.5;
-			case "M":
-				return 1;
-			case "L":
-				return 2;
-			case "XL":
-				return 4;
-			default:
-				return 2;
+		if (freeLanes.length > 0) {
+			const laneIndex = freeLanes[Math.floor(Math.random() * freeLanes.length)];
+			return { topPx: scrollTopPx + laneIndex * laneHeightPx, laneIndex };
 		}
+
+		// 全レーン占有時はランダムフォールバック
+		const fallbackTopPx =
+			scrollTopPx +
+			Math.floor((availableHeightPx - fontSizePx) * Math.random());
+		return { topPx: fallbackTopPx, laneIndex: null };
 	};
 
-	const letterSize = screenHeight * 0.05 * letterSizeCoefficient();
-	comment.setAttribute("class", "google-meet-comment-flow");
-
-	const footerHeight = 88;
-	const scrollTopHeight = window.pageYOffset;
-	const availableHeight = screenHeight - footerHeight;
-
-	// レーン計算
-	const laneGap = letterSize * 0.2;
-	const laneHeight = letterSize + laneGap;
-	const laneCount = Math.max(1, Math.floor(availableHeight / laneHeight));
-
-	// DOM 上の既存コメント要素から占有中のレーンを取得
-	const occupiedLanes = new Set(
-		Array.from(
-			document.querySelectorAll(".google-meet-comment-flow[data-lane]"),
-		).map((el) => Number(el.getAttribute("data-lane"))),
-	);
-
-	// 空きレーンからランダムに選択
-	const freeLanes = Array.from({ length: laneCount }, (_, i) => i).filter(
-		(i) => !occupiedLanes.has(i),
-	);
-
-	let topPosition: number;
-	let selectedLane: number | null = null;
-
-	if (freeLanes.length > 0) {
-		selectedLane = freeLanes[Math.floor(Math.random() * freeLanes.length)];
-		topPosition = scrollTopHeight + selectedLane * laneHeight;
-	} else {
-		// 全レーン占有時：従来通りランダム配置
-		topPosition =
-			scrollTopHeight +
-			Math.floor((availableHeight - letterSize) * Math.random());
-	}
-
-	if (selectedLane !== null) {
-		comment.setAttribute("data-lane", String(selectedLane));
-	}
-
-	const commentStyle = {
-		left: `${screenWidth}px`,
-		top: `${topPosition}px`,
-		fontSize: `${letterSize}px`,
-	};
-
-	const storedColorMessage = await chrome.runtime.sendMessage({
-		method: "getColor",
-	});
-
-	// ユーザー名からハッシュ値を計算し、HSL色空間で色を決定する
+	// ユーザー名を HSL の hue に変換して、投稿者ごとに安定した色を割り当てる
 	const usernameToColor = (username: string): string => {
 		let hash = 0;
 		for (let i = 0; i < username.length; i++) {
@@ -109,46 +82,86 @@ export const injectComment = async (
 		return `hsl(${hue}, 70%, 60%)`;
 	};
 
-	const resolveColor = (): string => {
-		if (author) {
-			return usernameToColor(author);
-		}
-		return storedColorMessage || "green";
+	const resolveColor = (storedColor: string | undefined): string => {
+		if (author) return usernameToColor(author);
+		return storedColor || DEFAULT_COLOR;
 	};
 
-	comment.style.left = commentStyle.left;
-	comment.style.top = commentStyle.top;
-	comment.style.fontSize = commentStyle.fontSize;
+	const applyCommentStyles = (
+		el: HTMLElement,
+		leftPx: number,
+		topPx: number,
+		fontSizePx: number,
+		color: string,
+	) => {
+		el.style.position = "absolute";
+		el.style.left = `${leftPx}px`;
+		el.style.top = `${topPx}px`;
+		el.style.fontSize = `${fontSizePx}px`;
+		el.style.color = color;
+		el.style.zIndex = MAX_Z_INDEX;
+		el.style.whiteSpace = "nowrap";
+		el.style.lineHeight = "initial";
+	};
 
-	comment.style.color = resolveColor();
+	const animateComment = (
+		el: HTMLElement,
+		screenWidthPx: number,
+	): Animation => {
+		const travelDistancePx = screenWidthPx + el.offsetWidth;
+		const durationMs = (travelDistancePx / SPEED_PX_PER_SEC) * 1000;
 
-	comment.style.position = "absolute";
-	comment.style.zIndex = "2147483647";
-	comment.style.whiteSpace = "nowrap";
-	comment.style.lineHeight = "initial";
+		return el.animate(
+			{ left: `${-el.offsetWidth}px` },
+			{ duration: durationMs, easing: "linear" },
+		);
+	};
 
-	// 一定速度 (px/sec) で流す。移動距離 = 画面幅 + テキスト幅
-	const SPEED_PX_PER_SEC = 400;
-	const travelDistance = screenWidth + comment.offsetWidth;
-	const duration = (travelDistance / SPEED_PX_PER_SEC) * 1000;
+	// --- main flow ---
+	const screenHeightPx = window.innerHeight;
+	const screenWidthPx = window.innerWidth;
 
-	const streamCommentUI = comment.animate(
-		{
-			left: `${-comment.offsetWidth}px`,
-		},
-		{
-			duration,
-			easing: "linear",
-		},
+	const [storedFontSize, storedColor] = await Promise.all([
+		chrome.runtime.sendMessage({ method: "getFontSize" }),
+		chrome.runtime.sendMessage({ method: "getColor" }),
+	]);
+
+	const targetNode = resolveTargetNode();
+	const fontSizePx = resolveFontSizePx(screenHeightPx, storedFontSize);
+
+	const commentEl = document.createElement("span");
+	commentEl.textContent = message;
+	commentEl.setAttribute("class", COMMENT_CLASS);
+	targetNode.appendChild(commentEl);
+
+	const availableHeightPx = screenHeightPx - FOOTER_HEIGHT_PX;
+	const scrollTopPx = window.pageYOffset;
+	const { topPx, laneIndex } = pickLanePlacement(
+		fontSizePx,
+		availableHeightPx,
+		scrollTopPx,
+	);
+	if (laneIndex !== null) {
+		commentEl.setAttribute(LANE_ATTR, String(laneIndex));
+	}
+
+	applyCommentStyles(
+		commentEl,
+		screenWidthPx,
+		topPx,
+		fontSizePx,
+		resolveColor(storedColor),
 	);
 
-	// NOTE: 表示中の commentId と一致する場合のみ削除する。連続投稿時に
-	// 新しいコメントを誤って消さないための安全策。
-	streamCommentUI.ready.then(() =>
+	const animation = animateComment(commentEl, screenWidthPx);
+
+	// 表示中の commentId と一致する場合のみ storage から削除し、
+	// 連続投稿時に新しいコメントを誤削除するのを防ぐ。
+	animation.ready.then(() =>
 		chrome.runtime.sendMessage({ method: "deleteComment", commentId }),
 	);
 
-	streamCommentUI.onfinish = () => {
-		targetNode.removeChild(comment);
+	animation.onfinish = () => {
+		targetNode.removeChild(commentEl);
 	};
 };

--- a/src/contentScripts/extractors/googleChat.ts
+++ b/src/contentScripts/extractors/googleChat.ts
@@ -1,0 +1,38 @@
+import type { ExtractedComment } from "./types";
+
+// Google Meet が Google Chat ベースのチャットに移行した後の構造:
+//   div[jsname="yoHpJ"]                           ← チャットコンテナ
+//     └── c-wiz[data-is-user-topic="true"]        ← メッセージトピック
+//           ├── span[jsname="oU6v8b"][data-name]  ← 投稿者名
+//           └── div[jsname="bgckF"]               ← メッセージ本文
+const GCHAT_SELECTORS = {
+	container: 'div[jsname="yoHpJ"]',
+	messageThread: 'c-wiz[data-is-user-topic="true"]',
+	messageText: 'div[jsname="bgckF"]',
+	author: 'span[jsname="oU6v8b"]',
+} as const;
+
+// 同じトピック ID を複数回拾わないための module-local state
+let lastSeenTopicId = "";
+
+export const extractFromGoogleChat = (): ExtractedComment | undefined => {
+	const container = document.querySelector(GCHAT_SELECTORS.container);
+	if (!container) return;
+
+	const topics = container.querySelectorAll(GCHAT_SELECTORS.messageThread);
+	if (topics.length === 0) return;
+
+	const lastTopic = topics[topics.length - 1];
+	const topicId = lastTopic.getAttribute("data-topic-id");
+	if (!topicId || topicId === lastSeenTopicId) return;
+	lastSeenTopicId = topicId;
+
+	const messageEl = lastTopic.querySelector(GCHAT_SELECTORS.messageText);
+	const message = messageEl?.textContent?.trim();
+	if (!message) return;
+
+	const authorEl = lastTopic.querySelector(GCHAT_SELECTORS.author);
+	const author = authorEl?.getAttribute("data-name") ?? undefined;
+
+	return { message, author };
+};

--- a/src/contentScripts/extractors/legacyChat.ts
+++ b/src/contentScripts/extractors/legacyChat.ts
@@ -1,0 +1,85 @@
+import type { CommentExtractor, ExtractedComment } from "./types";
+
+// 旧エフェメラルチャット（チャットパネル）
+const LEGACY_PANEL_BASE = "div.WUFI9b[data-panel-id='2']";
+const LEGACY_PANEL_SELECTORS = {
+	container: LEGACY_PANEL_BASE,
+	thread: `${LEGACY_PANEL_BASE} > div.hWX4r div.z38b6`,
+	message: `${LEGACY_PANEL_BASE} > div.hWX4r div.z38b6 div[jsname="dTKtvb"] > div`,
+	hiddenClass: "qdulke",
+	asideClass: "aside.R3Gmyc",
+} as const;
+
+// 旧ポップアップチャット（会議中の吹き出し表示）
+const LEGACY_POPUP_BASE = "div.fJsklc.nulMpf.Didmac.sOkDId";
+const LEGACY_POPUP_SELECTORS = {
+	thread: `${LEGACY_POPUP_BASE} > div.mIw6Bf.nTlZFe.P9KVBf`,
+	message: `${LEGACY_POPUP_BASE} > div.mIw6Bf.nTlZFe.P9KVBf div[jsname="dTKtvb"] > div`,
+} as const;
+
+// jsname="Ypafjf" = メッセージグループ、jsname="biJjHb" = タイムスタンプ
+// タイムスタンプの兄弟に投稿者名があるが、自分のメッセージには存在しない
+const extractAuthorFromMessageNode = (
+	messageNode: Element,
+): string | undefined => {
+	const messageGroup = messageNode.closest('[jsname="Ypafjf"]');
+	if (!messageGroup) return undefined;
+
+	const timestampEl = messageGroup.querySelector('[jsname="biJjHb"]');
+	if (!timestampEl?.parentElement) return undefined;
+
+	for (const sibling of Array.from(timestampEl.parentElement.children)) {
+		if (sibling === timestampEl) continue;
+		const text = sibling.textContent?.trim();
+		if (text) return text;
+	}
+	return undefined;
+};
+
+// スレッド要素の差分を検出しつつ最新メッセージを返す抽出器を生成する factory。
+// 旧チャットと旧ポップアップは構造が似ているためセレクタ差し替えで共通化できる。
+const createThreadExtractor = (
+	getThread: () => Element | null,
+	messageSelector: string,
+): CommentExtractor => {
+	let lastSnapshot: Node | undefined;
+
+	return (): ExtractedComment | undefined => {
+		const thread = getThread();
+		if (!thread || thread.isEqualNode(lastSnapshot ?? null)) return;
+
+		lastSnapshot = thread.cloneNode(true);
+
+		const messageNodes = thread.querySelectorAll(messageSelector);
+		if (messageNodes.length === 0) return;
+
+		const messageNode = messageNodes[messageNodes.length - 1];
+		const author = extractAuthorFromMessageNode(messageNode);
+
+		return { message: messageNode.innerHTML, author };
+	};
+};
+
+const isLegacyChatPanelVisible = (): boolean => {
+	const panel = document.querySelector(LEGACY_PANEL_SELECTORS.container);
+	const aside = panel?.closest(LEGACY_PANEL_SELECTORS.asideClass);
+	return (
+		!!aside && !aside.classList.contains(LEGACY_PANEL_SELECTORS.hiddenClass)
+	);
+};
+
+const extractFromLegacyPanel = createThreadExtractor(
+	() => document.querySelector(LEGACY_PANEL_SELECTORS.thread),
+	LEGACY_PANEL_SELECTORS.message,
+);
+
+const extractFromLegacyPopup = createThreadExtractor(
+	() => document.querySelector(LEGACY_POPUP_SELECTORS.thread),
+	LEGACY_POPUP_SELECTORS.message,
+);
+
+export const extractFromLegacyChat: CommentExtractor = () => {
+	return isLegacyChatPanelVisible()
+		? extractFromLegacyPanel()
+		: extractFromLegacyPopup();
+};

--- a/src/contentScripts/extractors/types.ts
+++ b/src/contentScripts/extractors/types.ts
@@ -1,0 +1,6 @@
+export type ExtractedComment = {
+	message: string;
+	author: string | undefined;
+};
+
+export type CommentExtractor = () => ExtractedComment | undefined;

--- a/src/contentScripts/saveComment.ts
+++ b/src/contentScripts/saveComment.ts
@@ -1,183 +1,42 @@
+import { extractFromGoogleChat } from "./extractors/googleChat";
+import { extractFromLegacyChat } from "./extractors/legacyChat";
+import type { CommentExtractor } from "./extractors/types";
 import { decodeHTMLSpecialWord } from "./utils/decodeHTMLSpecialWord";
 
-let prevThread: Node;
+// 新 Google Chat 統合型を優先し、検出できなければ旧チャットにフォールバック
+const EXTRACTORS: readonly CommentExtractor[] = [
+	extractFromGoogleChat,
+	extractFromLegacyChat,
+];
 
-let prevPopupThread: Node;
-
-// --- 旧エフェメラルチャット用セレクタ ---
-const CHAT_SELECTOR_BASE = "div.WUFI9b[data-panel-id='2']";
-
-const CHAT_SELECTOR_OBJ = {
-	container: CHAT_SELECTOR_BASE,
-	thread: `${CHAT_SELECTOR_BASE} > div.hWX4r div.z38b6`,
-	message: `${CHAT_SELECTOR_BASE} > div.hWX4r div.z38b6 div[jsname="dTKtvb"] > div`,
-} as const;
-
-const CHAT_CLASS_OBJ = {
-	isHidden: "qdulke",
-} as const;
-
-const POPUP_SELECTOR_BASE = "div.fJsklc.nulMpf.Didmac.sOkDId";
-
-const POPUP_SELECTOR_OBJ = {
-	container: POPUP_SELECTOR_BASE,
-	thread: `${POPUP_SELECTOR_BASE} > div.mIw6Bf.nTlZFe.P9KVBf`,
-	message: `${POPUP_SELECTOR_BASE} > div.mIw6Bf.nTlZFe.P9KVBf div[jsname="dTKtvb"] > div`,
-} as const;
-
-// --- 新 Google Chat 統合型チャット用セレクタ ---
-// Google Meet が Google Chat ベースのチャットに移行したため、
-// jsname 属性ベースのセレクタで安定的にメッセージを取得する。
-//
-// 構造:
-//   div[jsname="yoHpJ"]                           ← チャットコンテナ
-//     └── c-wiz[data-is-user-topic="true"]        ← メッセージトピック
-//           ├── span[jsname="oU6v8b"][data-name]  ← 投稿者名
-//           └── div[jsname="bgckF"]               ← メッセージ本文
-const GCHAT_SELECTOR_OBJ = {
-	container: 'div[jsname="yoHpJ"]',
-	messageThread: 'c-wiz[data-is-user-topic="true"]',
-	messageText: 'div[jsname="bgckF"]',
-	author: 'span[jsname="oU6v8b"]',
-} as const;
-
-let lastGChatTopicId = "";
-
-type ExtractedComment = {
-	message: string;
-	author: string | undefined;
-};
-
-/**
- * Google Chat 統合型チャットから最新メッセージを取得する。
- * data-topic-id で重複検知を行う。
- */
-const extractMessageFromGChat = (
-	container: Element | null,
-): ExtractedComment | undefined => {
-	if (!container) return;
-
-	const topics = container.querySelectorAll(GCHAT_SELECTOR_OBJ.messageThread);
-	if (topics.length === 0) return;
-
-	const lastTopic = topics[topics.length - 1];
-	const topicId = lastTopic.getAttribute("data-topic-id");
-
-	if (!topicId || topicId === lastGChatTopicId) return;
-	lastGChatTopicId = topicId;
-
-	const messageEl = lastTopic.querySelector(GCHAT_SELECTOR_OBJ.messageText);
-	if (!messageEl) return;
-
-	const message = messageEl.textContent?.trim();
-	if (!message) return;
-
-	const authorEl = lastTopic.querySelector(GCHAT_SELECTOR_OBJ.author);
-	const author = authorEl?.getAttribute("data-name") ?? undefined;
-
-	return { message, author };
-};
-
-/**
- * メッセージノードの祖先を辿り、投稿者名を取得する（旧チャット用）。
- * クラス名は変更されやすいため、jsname 属性を基準にDOMを探索する。
- *
- * 構造:
- *   div[jsname="Ypafjf"]  ← メッセージグループ
- *     └── ... > div (ヘッダー)
- *           ├── div  ← 投稿者名（自分のメッセージでは存在しない）
- *           └── div[jsname="biJjHb"]  ← タイムスタンプ
- */
-const extractAuthorFromMessageNode = (
-	messageNode: Element,
-): string | undefined => {
-	const messageGroup = messageNode.closest('[jsname="Ypafjf"]');
-	if (!messageGroup) return undefined;
-
-	// タイムスタンプ要素の親（ヘッダー）内で、タイムスタンプ以外のテキスト要素を探す
-	const timestampEl = messageGroup.querySelector('[jsname="biJjHb"]');
-	if (!timestampEl?.parentElement) return undefined;
-
-	for (const sibling of Array.from(timestampEl.parentElement.children)) {
-		if (sibling === timestampEl) continue;
-		const text = sibling.textContent?.trim();
-		if (text) return text;
+const extractLatestComment = () => {
+	for (const extract of EXTRACTORS) {
+		const extracted = extract();
+		if (extracted) return extracted;
 	}
-
 	return undefined;
 };
 
-const extractMessageFromPopupThread = (
-	popupThread: Element | null,
-): ExtractedComment | undefined => {
-	if (!popupThread || popupThread.isEqualNode(prevPopupThread)) return;
+const hasElementAddedNode = (mutations: MutationRecord[]): boolean =>
+	mutations.some((m) =>
+		Array.from(m.addedNodes).some((n) => n.nodeType === Node.ELEMENT_NODE),
+	);
 
-	prevPopupThread = popupThread.cloneNode(true);
-
-	const messageNodes = popupThread.querySelectorAll(POPUP_SELECTOR_OBJ.message);
-
-	if (messageNodes.length === 0) return;
-
-	const messageNode = messageNodes[messageNodes.length - 1];
-	const author = extractAuthorFromMessageNode(messageNode);
-
-	return { message: messageNode.innerHTML, author };
-};
-
-const extractMessageFromThread = (
-	thread: Element | null,
-): ExtractedComment | undefined => {
-	if (!thread || thread.isEqualNode(prevThread)) return;
-
-	prevThread = thread.cloneNode(true);
-
-	const messageNodes = thread.querySelectorAll(CHAT_SELECTOR_OBJ.message);
-
-	if (messageNodes.length === 0) return;
-
-	const messageNode = messageNodes[messageNodes.length - 1];
-	const author = extractAuthorFromMessageNode(messageNode);
-
-	return { message: messageNode.innerHTML, author };
-};
-
-const observer = new MutationObserver(async (mutations: MutationRecord[]) => {
+const observer = new MutationObserver(async (mutations) => {
 	try {
 		if (!chrome.runtime?.id) {
 			observer.disconnect();
 			return;
 		}
 
-		const addedNode = mutations[0].addedNodes?.[0];
-
-		if (addedNode?.nodeType !== Node.ELEMENT_NODE) return;
+		if (!hasElementAddedNode(mutations)) return;
 
 		const isEnabledStreaming = await chrome.runtime.sendMessage({
 			method: "getIsEnabledStreaming",
 		});
-
 		if (!isEnabledStreaming) return;
 
-		// 新 Google Chat 統合型チャットを優先して検出
-		const gChatContainer = document.querySelector(GCHAT_SELECTOR_OBJ.container);
-		let extracted = extractMessageFromGChat(gChatContainer);
-
-		// 旧エフェメラルチャットにフォールバック
-		if (!extracted) {
-			const popupThread = document.querySelector(POPUP_SELECTOR_OBJ.thread);
-
-			const chatPanel = document.querySelector(CHAT_SELECTOR_OBJ.container);
-			const chatPanelAside = chatPanel?.closest("aside.R3Gmyc");
-			const isChatVisible =
-				chatPanelAside &&
-				!chatPanelAside.classList.contains(CHAT_CLASS_OBJ.isHidden);
-			const thread = document.querySelector(CHAT_SELECTOR_OBJ.thread);
-
-			extracted = isChatVisible
-				? extractMessageFromThread(thread)
-				: extractMessageFromPopupThread(popupThread);
-		}
-
+		const extracted = extractLatestComment();
 		if (!extracted) return;
 
 		chrome.runtime.sendMessage({
@@ -190,9 +49,11 @@ const observer = new MutationObserver(async (mutations: MutationRecord[]) => {
 	}
 });
 
-document.addEventListener("DOMContentLoaded", () =>
-	observer.observe(document.body, {
-		subtree: true,
-		childList: true,
-	}),
-);
+const startObserving = () =>
+	observer.observe(document.body, { subtree: true, childList: true });
+
+if (document.readyState === "loading") {
+	document.addEventListener("DOMContentLoaded", startObserving);
+} else {
+	startObserving();
+}

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -1,36 +1,18 @@
 import "./App.css";
 import { type ChangeEvent, useEffect, useState } from "react";
-
-const Colors = {
-	Auto: "auto",
-	Black: "black",
-	Red: "red",
-	Orange: "orange",
-	Yellow: "yellow",
-	Green: "green",
-	Blue: "blue",
-	Indigo: "indigo",
-	Purple: "purple",
-} as const;
-
-type Color = (typeof Colors)[keyof typeof Colors];
-
-const FontSizes = { Xs: "XS", S: "S", M: "M", L: "L", Xl: "XL" } as const;
-
-type FontSize = (typeof FontSizes)[keyof typeof FontSizes];
-
-const isColor = (value: string): value is Color => {
-	return Object.values(Colors).some((color) => color === value);
-};
-
-const isFontSize = (value: string): value is FontSize => {
-	return Object.values(FontSizes).some((fontSize) => fontSize === value);
-};
+import {
+	COLORS,
+	type Color,
+	DEFAULT_FONT_SIZE,
+	FONT_SIZES,
+	type FontSize,
+	isColor,
+	isFontSize,
+} from "../shared/settings";
 
 const App = () => {
-	const [color, setColor] = useState<Color>(Colors.Auto);
-
-	const [fontSize, setFontSize] = useState<FontSize>(FontSizes.L);
+	const [color, setColor] = useState<Color>(COLORS.Auto);
+	const [fontSize, setFontSize] = useState<FontSize>(DEFAULT_FONT_SIZE);
 	const [isEnabledStreaming, setIsEnabledStreaming] = useState<boolean>(false);
 
 	const handleChangeColor = (e: ChangeEvent<HTMLSelectElement>) => {
@@ -38,10 +20,7 @@ const App = () => {
 		if (!isColor(value)) return;
 
 		setColor(value);
-		chrome.runtime.sendMessage({
-			method: "setColor",
-			value,
-		});
+		chrome.runtime.sendMessage({ method: "setColor", value });
 	};
 
 	const handleChangeFontSize = (e: ChangeEvent<HTMLSelectElement>) => {
@@ -49,53 +28,28 @@ const App = () => {
 		if (!isFontSize(value)) return;
 
 		setFontSize(value);
-		chrome.runtime.sendMessage({
-			method: "setFontSize",
-			value,
-		});
+		chrome.runtime.sendMessage({ method: "setFontSize", value });
 	};
 
 	const handleChangeIsEnabledStreaming = () => {
 		const value = !isEnabledStreaming;
 
 		setIsEnabledStreaming(value);
-		chrome.runtime.sendMessage({
-			method: "setIsEnabledStreaming",
-			value,
-		});
+		chrome.runtime.sendMessage({ method: "setIsEnabledStreaming", value });
 	};
 
 	useEffect(() => {
-		const setDataFromLocalStorage = async () => {
+		const loadStoredSettings = async () => {
 			try {
-				const storedColorMessage = chrome.runtime.sendMessage({
-					method: "getColor",
-				});
-				const storedFontSizeMessage = chrome.runtime.sendMessage({
-					method: "getFontSize",
-				});
-				const storedIsEnabledStreamingMessage = chrome.runtime.sendMessage({
-					method: "getIsEnabledStreaming",
-				});
+				const [storedColor, storedFontSize, storedIsEnabledStreaming] =
+					await Promise.all([
+						chrome.runtime.sendMessage({ method: "getColor" }),
+						chrome.runtime.sendMessage({ method: "getFontSize" }),
+						chrome.runtime.sendMessage({ method: "getIsEnabledStreaming" }),
+					]);
 
-				const fetchedData = await Promise.all([
-					storedColorMessage,
-					storedFontSizeMessage,
-					storedIsEnabledStreamingMessage,
-				]);
-
-				const storedColor = fetchedData[0];
-				const storedFontSize = fetchedData[1];
-				const storedIsEnabledStreaming = fetchedData[2];
-
-				if (storedColor && isColor(storedColor)) {
-					setColor(storedColor);
-				}
-
-				if (storedFontSize && isFontSize(storedFontSize)) {
-					setFontSize(storedFontSize);
-				}
-
+				if (isColor(storedColor)) setColor(storedColor);
+				if (isFontSize(storedFontSize)) setFontSize(storedFontSize);
 				if (typeof storedIsEnabledStreaming === "boolean") {
 					setIsEnabledStreaming(storedIsEnabledStreaming);
 				}
@@ -104,7 +58,7 @@ const App = () => {
 			}
 		};
 
-		setDataFromLocalStorage();
+		loadStoredSettings();
 	}, []);
 
 	return (
@@ -119,9 +73,9 @@ const App = () => {
 						value={color}
 						onChange={handleChangeColor}
 					>
-						{Object.values(Colors).map((color) => (
-							<option key={color} value={color}>
-								{color}
+						{Object.values(COLORS).map((c) => (
+							<option key={c} value={c}>
+								{c}
 							</option>
 						))}
 					</select>
@@ -134,9 +88,9 @@ const App = () => {
 						value={fontSize}
 						onChange={handleChangeFontSize}
 					>
-						{Object.values(FontSizes).map((fontSize) => (
-							<option key={fontSize} value={fontSize}>
-								{fontSize}
+						{Object.values(FONT_SIZES).map((fs) => (
+							<option key={fs} value={fs}>
+								{fs}
 							</option>
 						))}
 					</select>

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -1,0 +1,42 @@
+export const COLORS = {
+	Auto: "auto",
+	Black: "black",
+	Red: "red",
+	Orange: "orange",
+	Yellow: "yellow",
+	Green: "green",
+	Blue: "blue",
+	Indigo: "indigo",
+	Purple: "purple",
+} as const;
+
+export type Color = (typeof COLORS)[keyof typeof COLORS];
+
+export const FONT_SIZES = {
+	Xs: "XS",
+	S: "S",
+	M: "M",
+	L: "L",
+	Xl: "XL",
+} as const;
+
+export type FontSize = (typeof FONT_SIZES)[keyof typeof FONT_SIZES];
+
+export const FONT_SIZE_COEFFICIENTS: Record<FontSize, number> = {
+	XS: 0.25,
+	S: 0.5,
+	M: 1,
+	L: 2,
+	XL: 4,
+};
+
+export const DEFAULT_FONT_SIZE: FontSize = "L";
+export const DEFAULT_COLOR_FALLBACK = "green";
+
+export const isColor = (value: unknown): value is Color =>
+	typeof value === "string" &&
+	Object.values(COLORS).some((color) => color === value);
+
+export const isFontSize = (value: unknown): value is FontSize =>
+	typeof value === "string" &&
+	Object.values(FONT_SIZES).some((fontSize) => fontSize === value);


### PR DESCRIPTION
## Summary
レビュー結果の Mid 優先度項目を反映。PR #34 にスタックしているので、先に #34 をマージしてから本 PR をレビューしてください（base: \`refactor/message-routing-and-race-fix\`）。

### `src/background/injectComment.ts`
- 149 行の単一関数を 7 つの helper に分解: \`resolveTargetNode\` / \`resolveFontSizePx\` / \`pickLanePlacement\` / \`applyCommentStyles\` / \`animateComment\` / \`usernameToColor\` / \`resolveColor\`
- magic number を定数化: \`SPEED_PX_PER_SEC\`, \`FOOTER_HEIGHT_PX\`, \`BASE_FONT_SIZE_RATIO\`, \`LANE_GAP_RATIO\`, \`DEFAULT_COLOR\`, \`COMMENT_CLASS\`, \`LANE_ATTR\`, \`MAX_Z_INDEX\`
- \`FONT_SIZE_COEFFICIENTS\` をテーブル化（switch → Record）
- fontSize / color を \`Promise.all\` で並列取得
- 変数名リネーム: \`letterSize\` → \`fontSizePx\`, \`streamCommentUI\` → \`animation\`, \`storedFontSizeMessage\` → \`storedFontSize\` 等
- ⚠️ \`executeScript\` で page context に注入される制約により、shared/settings の定数は import せず関数内に再定義（重複は許容）

### `src/contentScripts/extractors/`（新規）
- \`googleChat.ts\`: 新 Google Chat 統合型
- \`legacyChat.ts\`: 旧エフェメラル／ポップアップ（\`createThreadExtractor\` factory で共通化、 duplication 解消）
- \`types.ts\`: \`ExtractedComment\` / \`CommentExtractor\`

### `src/contentScripts/saveComment.ts`
- orchestration のみに縮小、\`EXTRACTORS\` 配列で順次試行する形に
- MutationObserver が最初の mutation しか見ていなかったバグを修正（\`hasElementAddedNode\` で全走査）
- \`document.readyState\` 分岐で late-injection にも対応

### `src/popup/App.tsx`
- \`Color\` / \`FontSize\` / \`isColor\` / \`isFontSize\` を \`shared/settings.ts\` に移動
- 初期化 \`useEffect\` を分割代入と直接 \`isColor\`/\`isFontSize\` 呼び出しに整理

## Test plan
- [ ] \`pnpm check\`（Biome）がパスすること
- [ ] \`pnpm build\` がエラーなく通ること
- [ ] コメント投稿でコメントが流れること
- [ ] 新 GChat / 旧チャット / ポップアップそれぞれで動作
- [ ] フォントサイズ XS/S/M/L/XL が従来どおり反映されること
- [ ] レーン分けが従来どおり動作すること
- [ ] Color を auto 以外にした場合に色が反映されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)