### PR TITLE
chore: bump version to 1.0.8

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import { crx, defineManifest } from "@crxjs/vite-plugin";
 const manifest = defineManifest({
   manifest_version: 3,
   name: "Comment Stream for Meet",
-  version: "1.0.7",
+  version: "1.0.8",
   permissions: ["storage", "scripting"],
   host_permissions: ["http://*/*", "https://*/*"],
   action: {


### PR DESCRIPTION
## Summary
- manifest version を 1.0.7 → 1.0.8 に bump

## 1.0.8 の主な変更
- Google Chat 統合型チャット対応 (#33)
- background メッセージルーティング分解・レース修正 (#34)
- injectComment 関数分解 / extractor factory 化 / 変数名整理 (#35)

## Test plan
- [x] ローカルで動作検証済み
- [ ] マージ後に `v1.0.8` タグを push すると `deploy-to-store.yml` が Chrome Web Store に自動デプロイ

🤖 Generated with [Claude Code](https://claude.com/claude-code)