### PR TITLE
fix: injectComment の lane 占有判定で data-lane 欠落時の lane 0 誤占有を防ぐ

### DIFF
--- a/src/background/injectComment.ts
+++ b/src/background/injectComment.ts
@@ -50,9 +50,9 @@ export const injectComment = async (
 		const laneCount = Math.max(1, Math.floor(availableHeightPx / laneHeightPx));
 
 		const occupiedLanes = new Set(
-			Array.from(
-				document.querySelectorAll(`.${COMMENT_CLASS}[${LANE_ATTR}]`),
-			).map((el) => Number(el.getAttribute(LANE_ATTR))),
+			Array.from(document.querySelectorAll(`.${COMMENT_CLASS}[${LANE_ATTR}]`))
+				.map((el) => Number(el.getAttribute(LANE_ATTR)))
+				.filter((n) => Number.isFinite(n)),
 		);
 
 		const freeLanes = Array.from({ length: laneCount }, (_, i) => i).filter(


### PR DESCRIPTION
## Summary
- `data-lane` 属性が数値に変換できない場合 `Number(null)` / `NaN` を `Set` に入れてしまうのを防ぐ
- `Number.isFinite` で明示的にフィルタ

Closes #39

## Test plan
- [x] `pnpm check` が通る
- [x] `pnpm build` が通る
- [ ] Google Meet 上で複数コメント同時表示して lane 配置が破綻しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)