### PR TITLE
refactor: isEnabledStreaming を storage subscribe でキャッシュ化

### DIFF
--- a/src/contentScripts/saveComment.ts
+++ b/src/contentScripts/saveComment.ts
@@ -1,3 +1,4 @@
+import { STORAGE_KEYS } from "../shared/storageKeys";
 import { extractFromGoogleChat } from "./extractors/googleChat";
 import { extractFromLegacyChat } from "./extractors/legacyChat";
 import type { CommentExtractor } from "./extractors/types";
@@ -22,35 +23,58 @@ const hasElementAddedNode = (mutations: MutationRecord[]): boolean =>
 		Array.from(m.addedNodes).some((n) => n.nodeType === Node.ELEMENT_NODE),
 	);
 
-const observer = new MutationObserver(async (mutations) => {
+// mutation 毎に sendMessage すると高頻度時に round-trip が詰まり、
+// await 中の並走で同一コメントを重複送信するレースも起きうるため、
+// フラグは module-local にキャッシュし storage.onChanged で同期する。
+let isEnabledStreamingCache = false;
+
+const initStreamingFlagCache = async () => {
+	try {
+		const stored = await chrome.storage.local.get([
+			STORAGE_KEYS.IsEnabledStreaming,
+		]);
+		const value = stored[STORAGE_KEYS.IsEnabledStreaming];
+		isEnabledStreamingCache = value === true;
+	} catch (e) {
+		console.error(e);
+	}
+};
+
+chrome.storage.onChanged.addListener((changes) => {
+	const change = changes[STORAGE_KEYS.IsEnabledStreaming];
+	if (!change) return;
+	isEnabledStreamingCache = change.newValue === true;
+});
+
+const observer = new MutationObserver((mutations) => {
 	try {
 		if (!chrome.runtime?.id) {
 			observer.disconnect();
 			return;
 		}
 
+		if (!isEnabledStreamingCache) return;
 		if (!hasElementAddedNode(mutations)) return;
-
-		const isEnabledStreaming = await chrome.runtime.sendMessage({
-			method: "getIsEnabledStreaming",
-		});
-		if (!isEnabledStreaming) return;
 
 		const extracted = extractLatestComment();
 		if (!extracted) return;
 
-		chrome.runtime.sendMessage({
-			method: "setComment",
-			value: decodeHTMLSpecialWord(extracted.message),
-			author: extracted.author,
-		});
+		chrome.runtime
+			.sendMessage({
+				method: "setComment",
+				value: decodeHTMLSpecialWord(extracted.message),
+				author: extracted.author,
+			})
+			.catch((e) => console.error(e));
 	} catch (e) {
 		console.error(e);
 	}
 });
 
-const startObserving = () =>
+const startObserving = () => {
+	initStreamingFlagCache();
 	observer.observe(document.body, { subtree: true, childList: true });
+};
 
 if (document.readyState === "loading") {
 	document.addEventListener("DOMContentLoaded", startObserving);


### PR DESCRIPTION
## Summary
- MutationObserver 毎の `sendMessage({ method: \"getIsEnabledStreaming\" })` を廃止
- content script 起動時に一度取得して module-local にキャッシュ
- `chrome.storage.onChanged` で popup 側の変更を購読して同期
- MutationObserver は同期的にキャッシュを参照するだけに変更
- あわせて `setComment` の sendMessage に `.catch` を追加 (#47 の内容を先行対応)

## 背景
高頻度 mutation 時の round-trip コストと、await 中に次の mutation が走ることで同一コメントを重複送信するレースの懸念があった。各 extractor の重複防止ロジックで顕在化は避けていたが脆弱だったため恒久対応。

Closes #41
Partially closes #47

## Test plan
- [x] `pnpm check` が通る
- [x] `pnpm build` が通る
- [ ] popup の toggle ON/OFF が content script 側に即座に反映される
- [ ] Google Meet で複数コメント連投した際に重複なく流れる

🤖 Generated with [Claude Code](https://claude.com/claude-code)