### PR TITLE
refactor: messages.ts の value を Color / FontSize 型に narrow

### DIFF
--- a/src/background/handlers/settings.ts
+++ b/src/background/handlers/settings.ts
@@ -1,21 +1,23 @@
+import type { Color, FontSize } from "../../shared/settings";
+import { isColor, isFontSize } from "../../shared/settings";
 import { STORAGE_KEYS } from "../../shared/storageKeys";
 
-export const getColor = async (): Promise<string | undefined> => {
+export const getColor = async (): Promise<Color | undefined> => {
 	const stored = await chrome.storage.local.get([STORAGE_KEYS.Color]);
 	const value = stored[STORAGE_KEYS.Color];
-	return typeof value === "string" ? value : undefined;
+	return isColor(value) ? value : undefined;
 };
 
-export const setColor = (value: string) =>
+export const setColor = (value: Color) =>
 	chrome.storage.local.set({ [STORAGE_KEYS.Color]: value });
 
-export const getFontSize = async (): Promise<string | undefined> => {
+export const getFontSize = async (): Promise<FontSize | undefined> => {
 	const stored = await chrome.storage.local.get([STORAGE_KEYS.FontSize]);
 	const value = stored[STORAGE_KEYS.FontSize];
-	return typeof value === "string" ? value : undefined;
+	return isFontSize(value) ? value : undefined;
 };
 
-export const setFontSize = (value: string) =>
+export const setFontSize = (value: FontSize) =>
 	chrome.storage.local.set({ [STORAGE_KEYS.FontSize]: value });
 
 export const getIsEnabledStreaming = async (): Promise<boolean | undefined> => {

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -1,3 +1,5 @@
+import type { Color, FontSize } from "./settings";
+
 export type SetCommentRequest = {
 	method: "setComment";
 	value: string;
@@ -13,10 +15,10 @@ export type FlushCommentRequest = {
 	method: "flushComment";
 };
 
-export type SetColorRequest = { method: "setColor"; value: string };
+export type SetColorRequest = { method: "setColor"; value: Color };
 export type GetColorRequest = { method: "getColor" };
 
-export type SetFontSizeRequest = { method: "setFontSize"; value: string };
+export type SetFontSizeRequest = { method: "setFontSize"; value: FontSize };
 export type GetFontSizeRequest = { method: "getFontSize" };
 
 export type SetIsEnabledStreamingRequest = {


### PR DESCRIPTION
## Summary
- `SetColorRequest.value: string` → `Color`
- `SetFontSizeRequest.value: string` → `FontSize`
- background handler の `setColor` / `setFontSize` の引数型も narrow
- `getColor` / `getFontSize` を `isColor` / `isFontSize` ガード経由で narrow し、不正値は `undefined` を返す

popup 側は既に isColor / isFontSize ガードを通してから送っているため、破壊的変更なし。

Closes #42

## Test plan
- [x] `pnpm check` が通る
- [x] `pnpm build` が通る
- [ ] popup から色/フォントサイズを変更できる
- [ ] 拡張再起動後も設定が復元される

🤖 Generated with [Claude Code](https://claude.com/claude-code)