### PR TITLE
refactor: handler 関数名を実装に合わせてリネーム

### DIFF
--- a/src/background/handlers/comment.ts
+++ b/src/background/handlers/comment.ts
@@ -11,7 +11,7 @@ export const setComment = async (value: string, author?: string) => {
 };
 
 // 指定された commentId と一致する場合のみコメントを削除する（連続投稿時のレース防止）
-export const deleteCommentIfMatches = async (commentId: number) => {
+export const deleteCommentIfCurrent = async (commentId: number) => {
 	const stored = await chrome.storage.local.get([STORAGE_KEYS.CommentId]);
 	if (stored[STORAGE_KEYS.CommentId] !== commentId) return;
 
@@ -22,7 +22,7 @@ export const deleteCommentIfMatches = async (commentId: number) => {
 	]);
 };
 
-export const flushCommentToFocusedTab = async () => {
+export const flushCommentToActiveTab = async () => {
 	const stored = await chrome.storage.local.get([
 		STORAGE_KEYS.Comment,
 		STORAGE_KEYS.CommentAuthor,

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,7 +1,7 @@
 import type { MessageRequest } from "../shared/messages";
 import {
-	deleteCommentIfMatches,
-	flushCommentToFocusedTab,
+	deleteCommentIfCurrent,
+	flushCommentToActiveTab,
 	setComment,
 } from "./handlers/comment";
 import {
@@ -21,11 +21,11 @@ chrome.runtime.onMessage.addListener(
 				return false;
 
 			case "deleteComment":
-				deleteCommentIfMatches(request.commentId);
+				deleteCommentIfCurrent(request.commentId);
 				return false;
 
 			case "flushComment":
-				flushCommentToFocusedTab();
+				flushCommentToActiveTab();
 				return false;
 
 			case "setColor":


### PR DESCRIPTION
## Summary
- `deleteCommentIfMatches` → `deleteCommentIfCurrent`
  引数の `commentId` が「現在 storage にあるものと一致するか」を確認する意味を名前で明示
- `flushCommentToFocusedTab` → `flushCommentToActiveTab`
  実装は `chrome.tabs.query({ active, currentWindow })` なので "Active" が正確

`method` 名 (`deleteComment` / `flushComment`) は外部 API 的な位置づけのため変更なし。

Closes #45

## Test plan
- [x] `pnpm check` が通る
- [x] `pnpm build` が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)