### PR TITLE
refactor: decodeHTMLSpecialWord を decodeHtmlEntities にリネーム

### DIFF
--- a/src/contentScripts/saveComment.ts
+++ b/src/contentScripts/saveComment.ts
@@ -2,7 +2,7 @@ import { STORAGE_KEYS } from "../shared/storageKeys";
 import { extractFromGoogleChat } from "./extractors/googleChat";
 import { extractFromLegacyChat } from "./extractors/legacyChat";
 import type { CommentExtractor } from "./extractors/types";
-import { decodeHTMLSpecialWord } from "./utils/decodeHTMLSpecialWord";
+import { decodeHtmlEntities } from "./utils/decodeHtmlEntities";
 
 // 新 Google Chat 統合型を優先し、検出できなければ旧チャットにフォールバック
 const EXTRACTORS: readonly CommentExtractor[] = [
@@ -62,7 +62,7 @@ const observer = new MutationObserver((mutations) => {
 		chrome.runtime
 			.sendMessage({
 				method: "setComment",
-				value: decodeHTMLSpecialWord(extracted.message),
+				value: decodeHtmlEntities(extracted.message),
 				author: extracted.author,
 			})
 			.catch((e) => console.error(e));

--- a/src/contentScripts/utils/decodeHtmlEntities.ts
+++ b/src/contentScripts/utils/decodeHtmlEntities.ts
@@ -1,4 +1,4 @@
-export const decodeHTMLSpecialWord = (str: string): string => {
+export const decodeHtmlEntities = (str: string): string => {
 	return str
 		.replace(/&amp;/g, "&")
 		.replace(/&lt;/g, "<")


### PR DESCRIPTION
## Summary
- 関数名 `decodeHTMLSpecialWord` → `decodeHtmlEntities`
- ファイル名 `decodeHTMLSpecialWord.ts` → `decodeHtmlEntities.ts`
- 呼び出し元 `saveComment.ts` の import / 呼び出しを更新

"SpecialWord" は実態に合わない命名。ホワイトリスト置換の実装は XSS 安全なので維持する。

Closes #46

## Test plan
- [x] `pnpm check` が通る
- [x] `pnpm build` が通る
- [x] `pnpm knip` が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)