### PR TITLE
refactor: FONT_SIZE_COEFFICIENTS を shared に集約 (#60)

### DIFF
--- a/src/background/handlers/comment.ts
+++ b/src/background/handlers/comment.ts
@@ -1,3 +1,7 @@
+import {
+	DEFAULT_FONT_SIZE,
+	FONT_SIZE_COEFFICIENTS,
+} from "../../shared/settings";
 import { STORAGE_KEYS } from "../../shared/storageKeys";
 import { injectComment } from "../injectComment";
 
@@ -42,6 +46,8 @@ export const flushCommentToActiveTab = async () => {
 			String(comment),
 			String(stored[STORAGE_KEYS.CommentAuthor] ?? ""),
 			Number(stored[STORAGE_KEYS.CommentId] ?? 0),
+			FONT_SIZE_COEFFICIENTS,
+			FONT_SIZE_COEFFICIENTS[DEFAULT_FONT_SIZE],
 		],
 	});
 };

--- a/src/background/injectComment.ts
+++ b/src/background/injectComment.ts
@@ -1,13 +1,12 @@
 // NOTE: この関数は chrome.scripting.executeScript により対象タブのページコンテキストで実行される。
-//       そのためトップレベル import に依存できず、定数や helper もすべて関数内に閉じ込める必要がある。
-// SYNC:  shared/settings.ts の FONT_SIZES / DEFAULT_FONT_SIZE と以下の値を必ず揃えること。
-//         - FONT_SIZE_COEFFICIENTS のキー       ↔ FONT_SIZES の values (XS/S/M/L/XL)
-//         - DEFAULT_FONT_SIZE_COEFFICIENT の参照先 ↔ DEFAULT_FONT_SIZE ("L")
-//        片方だけ変更するとフォントサイズ選択 UI と injection の対応が壊れる。
+//       そのためトップレベル import に依存できず、定数・係数テーブル・デフォルト値はすべて
+//       呼び出し側 (background handler) から引数として渡す必要がある。
 export const injectComment = async (
 	message: string,
 	author: string,
 	commentId: number,
+	fontSizeCoefficients: Record<string, number>,
+	defaultFontSizeCoefficient: number,
 ) => {
 	// --- 定数 ---
 	const SPEED_PX_PER_SEC = 400;
@@ -18,16 +17,6 @@ export const injectComment = async (
 	const COMMENT_CLASS = "google-meet-comment-flow";
 	const LANE_ATTR = "data-lane";
 	const MAX_Z_INDEX = "2147483647";
-	// NOTE: キーは shared/settings.ts の FONT_SIZES の values と一致させる
-	const FONT_SIZE_COEFFICIENTS: Record<string, number> = {
-		XS: 0.25,
-		S: 0.5,
-		M: 1,
-		L: 2,
-		XL: 4,
-	};
-	// NOTE: shared/settings.ts の DEFAULT_FONT_SIZE ("L") と一致させる
-	const DEFAULT_FONT_SIZE_COEFFICIENT = FONT_SIZE_COEFFICIENTS.L;
 
 	// --- helpers ---
 	// Google Slide の全画面モードでは最大 z-index の overlay が存在するため、
@@ -40,8 +29,7 @@ export const injectComment = async (
 	};
 
 	const resolveFontSizePx = (screenHeightPx: number, key: string): number => {
-		const coefficient =
-			FONT_SIZE_COEFFICIENTS[key] ?? DEFAULT_FONT_SIZE_COEFFICIENT;
+		const coefficient = fontSizeCoefficients[key] ?? defaultFontSizeCoefficient;
 		return screenHeightPx * BASE_FONT_SIZE_RATIO * coefficient;
 	};
 

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -24,6 +24,14 @@ export type FontSize = (typeof FONT_SIZES)[keyof typeof FONT_SIZES];
 
 export const DEFAULT_FONT_SIZE: FontSize = "L";
 
+export const FONT_SIZE_COEFFICIENTS: Record<FontSize, number> = {
+	XS: 0.25,
+	S: 0.5,
+	M: 1,
+	L: 2,
+	XL: 4,
+};
+
 export const isColor = (value: unknown): value is Color =>
 	typeof value === "string" &&
 	Object.values(COLORS).some((color) => color === value);


### PR DESCRIPTION
## Summary

- `FONT_SIZE_COEFFICIENTS` を `shared/settings.ts` に移動し単一定義にする
- `injectComment` は係数テーブル / デフォルト係数を `executeScript.args` 経由で受け取る形に変更
- SYNC 用コメントが不要になり、`FONT_SIZES` に値を追加した際に型で検知できる

closes #60

## Test plan

- [x] `pnpm build` が通る
- [x] `pnpm check` が通る
- [x] `pnpm test:run` が通る
- [ ] 実機: popup でフォントサイズを変更しても injection が正しく動くこと