### PR TITLE
fix: streaming flag キャッシュを observe 前に初期化 (#62)

### DIFF
--- a/src/contentScripts/saveComment.ts
+++ b/src/contentScripts/saveComment.ts
@@ -71,8 +71,10 @@ const observer = new MutationObserver((mutations) => {
 	}
 });
 
-const startObserving = () => {
-	initStreamingFlagCache();
+const startObserving = async () => {
+	// observe 開始前に初期値を読むことで、有効化済みの状態で開かれた meet の
+	// 初期 DOM mutation を取り逃がさない (初期化完了前は cache が false のため)。
+	await initStreamingFlagCache();
 	observer.observe(document.body, { subtree: true, childList: true });
 };
 


### PR DESCRIPTION
## Summary

- `startObserving` を `async` にして `await initStreamingFlagCache()` してから `observer.observe()` を呼ぶ
- 有効化済み状態で meet を開いた直後の DOM mutation を取り逃がさないようにする
- 意図が分かるよう短いコメントを追記

closes #62

## Test plan

- [x] `pnpm build` が通る
- [x] `pnpm check` が通る
- [x] `pnpm test:run` が通る
- [ ] 実機: popup で Enable Streaming を ON にしたまま meet を開き直し、直後のチャットが拾えること