### PR TITLE
refactor: popup の設定読み込みを getSettings に集約 (#64)

### DIFF
--- a/src/background/handlers/settings.ts
+++ b/src/background/handlers/settings.ts
@@ -1,3 +1,4 @@
+import type { SettingsPayload } from "../../shared/messages";
 import type { Color, FontSize } from "../../shared/settings";
 import { isColor, isFontSize } from "../../shared/settings";
 import { STORAGE_KEYS } from "../../shared/storageKeys";
@@ -30,3 +31,23 @@ export const getIsEnabledStreaming = async (): Promise<boolean | undefined> => {
 
 export const setIsEnabledStreaming = (value: boolean) =>
 	chrome.storage.local.set({ [STORAGE_KEYS.IsEnabledStreaming]: value });
+
+// popup 初期化時に 3 設定を 1 message / 1 storage.get にまとめて取得する
+export const getSettings = async (): Promise<SettingsPayload> => {
+	const stored = await chrome.storage.local.get([
+		STORAGE_KEYS.Color,
+		STORAGE_KEYS.FontSize,
+		STORAGE_KEYS.IsEnabledStreaming,
+	]);
+
+	const color = stored[STORAGE_KEYS.Color];
+	const fontSize = stored[STORAGE_KEYS.FontSize];
+	const isEnabledStreaming = stored[STORAGE_KEYS.IsEnabledStreaming];
+
+	return {
+		color: isColor(color) ? color : undefined,
+		fontSize: isFontSize(fontSize) ? fontSize : undefined,
+		isEnabledStreaming:
+			typeof isEnabledStreaming === "boolean" ? isEnabledStreaming : undefined,
+	};
+};

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -8,6 +8,7 @@ import {
 	getColor,
 	getFontSize,
 	getIsEnabledStreaming,
+	getSettings,
 	setColor,
 	setFontSize,
 	setIsEnabledStreaming,
@@ -50,6 +51,10 @@ chrome.runtime.onMessage.addListener(
 
 			case "getIsEnabledStreaming":
 				getIsEnabledStreaming().then(sendResponse);
+				return true;
+
+			case "getSettings":
+				getSettings().then(sendResponse);
 				return true;
 
 			default: {

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -44,17 +44,14 @@ const App = () => {
 	useEffect(() => {
 		const loadStoredSettings = async () => {
 			try {
-				const [storedColor, storedFontSize, storedIsEnabledStreaming] =
-					await Promise.all([
-						chrome.runtime.sendMessage({ method: "getColor" }),
-						chrome.runtime.sendMessage({ method: "getFontSize" }),
-						chrome.runtime.sendMessage({ method: "getIsEnabledStreaming" }),
-					]);
+				const settings = await chrome.runtime.sendMessage({
+					method: "getSettings",
+				});
 
-				if (isColor(storedColor)) setColor(storedColor);
-				if (isFontSize(storedFontSize)) setFontSize(storedFontSize);
-				if (typeof storedIsEnabledStreaming === "boolean") {
-					setIsEnabledStreaming(storedIsEnabledStreaming);
+				if (isColor(settings?.color)) setColor(settings.color);
+				if (isFontSize(settings?.fontSize)) setFontSize(settings.fontSize);
+				if (typeof settings?.isEnabledStreaming === "boolean") {
+					setIsEnabledStreaming(settings.isEnabledStreaming);
 				}
 			} catch (e) {
 				console.error(e);

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -1,6 +1,13 @@
 import type { Color, FontSize } from "./settings";
 
-// 外部から参照されるのは MessageRequest (discriminated union) のみ。
+export type SettingsPayload = {
+	color: Color | undefined;
+	fontSize: FontSize | undefined;
+	isEnabledStreaming: boolean | undefined;
+};
+
+// 外部から参照されるのは MessageRequest (discriminated union) と
+// getSettings のレスポンス型 SettingsPayload のみ。
 // 個別の Request 型は union の要素として inline 定義し、method 文字列を
 // 一覧できる形に保つ。
 export type MessageRequest =
@@ -12,4 +19,5 @@ export type MessageRequest =
 	| { method: "setFontSize"; value: FontSize }
 	| { method: "getFontSize" }
 	| { method: "setIsEnabledStreaming"; value: boolean }
-	| { method: "getIsEnabledStreaming" };
+	| { method: "getIsEnabledStreaming" }
+	| { method: "getSettings" };


### PR DESCRIPTION
## Summary

- `getSettings` ハンドラを追加し、`chrome.storage.local.get([Color, FontSize, IsEnabledStreaming])` で 1 回で取得
- popup 起動時の `sendMessage` を 3 回 → 1 回に削減
- 既存の `getColor` / `getFontSize` / `getIsEnabledStreaming` は injectComment が参照しているため温存
- `SettingsPayload` 型を `shared/messages.ts` に追加

closes #64

## Test plan

- [x] `pnpm build` が通る
- [x] `pnpm check` が通る
- [x] `pnpm test:run` が通る
- [x] `pnpm knip` が未使用 export を検出しない
- [ ] 実機: popup を開いたときに 3 設定が正しく復元されること