### PR TITLE
refactor: injectComment の純粋ロジックを shared へ切り出す (#61)

### DIFF
--- a/src/background/injectComment.ts
+++ b/src/background/injectComment.ts
@@ -1,6 +1,12 @@
 // NOTE: この関数は chrome.scripting.executeScript により対象タブのページコンテキストで実行される。
 //       そのためトップレベル import に依存できず、定数・係数テーブル・デフォルト値はすべて
 //       呼び出し側 (background handler) から引数として渡す必要がある。
+//
+// STRUCTURE:
+//   1. constants        … マジックナンバー / DOM 属性名
+//   2. pure logic       … DOM / chrome API に依存しない計算 (shared/commentLogic.ts と同一ロジック)
+//   3. DOM side effects … 要素生成・配置・アニメーション登録
+//   4. main flow        … 上記を組み立てるエントリポイント
 export const injectComment = async (
 	message: string,
 	author: string,
@@ -8,9 +14,11 @@ export const injectComment = async (
 	fontSizeCoefficients: Record<string, number>,
 	defaultFontSizeCoefficient: number,
 ) => {
-	// --- 定数 ---
+	// ============================================================
+	// 1. constants
+	// ============================================================
 	const SPEED_PX_PER_SEC = 400;
-	const FOOTER_HEIGHT_PX = 88;
+	const FOOTER_HEIGHT_PX = 88; // Meet の下部ツールバー実測値
 	const BASE_FONT_SIZE_RATIO = 0.05; // 画面高さに対するフォントサイズ基準
 	const LANE_GAP_RATIO = 0.2; // フォントサイズに対するレーン間隔
 	const DEFAULT_COLOR = "green";
@@ -18,56 +26,17 @@ export const injectComment = async (
 	const LANE_ATTR = "data-lane";
 	const MAX_Z_INDEX = "2147483647";
 
-	// --- helpers ---
-	// Google Slide の全画面モードでは最大 z-index の overlay が存在するため、
-	// そちらに追加しないとコメントが埋もれる。
-	const resolveTargetNode = (): HTMLElement => {
-		const fullScreenOverlay = document.querySelector<HTMLElement>(
-			"body > div.punch-full-screen-element.punch-full-window-overlay",
-		);
-		return fullScreenOverlay ?? document.body;
-	};
-
+	// ============================================================
+	// 2. pure logic
+	//    shared/commentLogic.ts と同じロジックを inline 実装する。
+	//    executeScript 制約により import できないため、ロジック検証は
+	//    shared/commentLogic.test.ts 側で担保する。
+	// ============================================================
 	const resolveFontSizePx = (screenHeightPx: number, key: string): number => {
 		const coefficient = fontSizeCoefficients[key] ?? defaultFontSizeCoefficient;
 		return screenHeightPx * BASE_FONT_SIZE_RATIO * coefficient;
 	};
 
-	type LanePlacement = { topPx: number; laneIndex: number | null };
-
-	// NOTE: document.querySelectorAll で現在表示中のコメント要素を参照する副作用を持つ。
-	//       呼び出し側で配置前タイミングに限定すること。
-	const pickLanePlacement = (
-		fontSizePx: number,
-		availableHeightPx: number,
-		scrollTopPx: number,
-	): LanePlacement => {
-		const laneHeightPx = fontSizePx + fontSizePx * LANE_GAP_RATIO;
-		const laneCount = Math.max(1, Math.floor(availableHeightPx / laneHeightPx));
-
-		const occupiedLanes = new Set(
-			Array.from(document.querySelectorAll(`.${COMMENT_CLASS}[${LANE_ATTR}]`))
-				.map((el) => Number(el.getAttribute(LANE_ATTR)))
-				.filter((n) => Number.isFinite(n)),
-		);
-
-		const freeLanes = Array.from({ length: laneCount }, (_, i) => i).filter(
-			(i) => !occupiedLanes.has(i),
-		);
-
-		if (freeLanes.length > 0) {
-			const laneIndex = freeLanes[Math.floor(Math.random() * freeLanes.length)];
-			return { topPx: scrollTopPx + laneIndex * laneHeightPx, laneIndex };
-		}
-
-		// 全レーン占有時はランダムフォールバック
-		const fallbackTopPx =
-			scrollTopPx +
-			Math.floor((availableHeightPx - fontSizePx) * Math.random());
-		return { topPx: fallbackTopPx, laneIndex: null };
-	};
-
-	// ユーザー名を HSL の hue に変換して、投稿者ごとに安定した色を割り当てる
 	const usernameToColor = (username: string): string => {
 		let hash = 0;
 		for (let i = 0; i < username.length; i++) {
@@ -81,6 +50,67 @@ export const injectComment = async (
 	const resolveColor = (storedColor: string | undefined): string => {
 		if (author) return usernameToColor(author);
 		return storedColor || DEFAULT_COLOR;
+	};
+
+	const computeLaneLayout = (fontSizePx: number, availableHeightPx: number) => {
+		const laneHeightPx = fontSizePx + fontSizePx * LANE_GAP_RATIO;
+		const laneCount = Math.max(1, Math.floor(availableHeightPx / laneHeightPx));
+		return { laneHeightPx, laneCount };
+	};
+
+	const pickFreeLane = (
+		laneCount: number,
+		occupiedLanes: ReadonlySet<number>,
+	): number | null => {
+		const freeLanes: number[] = [];
+		for (let i = 0; i < laneCount; i++) {
+			if (!occupiedLanes.has(i)) freeLanes.push(i);
+		}
+		if (freeLanes.length === 0) return null;
+		return freeLanes[Math.floor(Math.random() * freeLanes.length)];
+	};
+
+	// ============================================================
+	// 3. DOM side effects
+	// ============================================================
+	// Google Slide の全画面モードでは最大 z-index の overlay が存在するため、
+	// そちらに追加しないとコメントが埋もれる。
+	const resolveTargetNode = (): HTMLElement => {
+		const fullScreenOverlay = document.querySelector<HTMLElement>(
+			"body > div.punch-full-screen-element.punch-full-window-overlay",
+		);
+		return fullScreenOverlay ?? document.body;
+	};
+
+	const readOccupiedLanes = (): Set<number> =>
+		new Set(
+			Array.from(document.querySelectorAll(`.${COMMENT_CLASS}[${LANE_ATTR}]`))
+				.map((el) => Number(el.getAttribute(LANE_ATTR)))
+				.filter((n) => Number.isFinite(n)),
+		);
+
+	type LanePlacement = { topPx: number; laneIndex: number | null };
+
+	const decideLanePlacement = (
+		fontSizePx: number,
+		availableHeightPx: number,
+		scrollTopPx: number,
+	): LanePlacement => {
+		const { laneHeightPx, laneCount } = computeLaneLayout(
+			fontSizePx,
+			availableHeightPx,
+		);
+		const laneIndex = pickFreeLane(laneCount, readOccupiedLanes());
+
+		if (laneIndex !== null) {
+			return { topPx: scrollTopPx + laneIndex * laneHeightPx, laneIndex };
+		}
+
+		// 全レーン占有時はランダムフォールバック
+		const fallbackTopPx =
+			scrollTopPx +
+			Math.floor((availableHeightPx - fontSizePx) * Math.random());
+		return { topPx: fallbackTopPx, laneIndex: null };
 	};
 
 	const applyCommentStyles = (
@@ -98,19 +128,6 @@ export const injectComment = async (
 		el.style.zIndex = MAX_Z_INDEX;
 		el.style.whiteSpace = "nowrap";
 		el.style.lineHeight = "initial";
-	};
-
-	const animateComment = (
-		el: HTMLElement,
-		screenWidthPx: number,
-	): Animation => {
-		const travelDistancePx = screenWidthPx + el.offsetWidth;
-		const durationMs = (travelDistancePx / SPEED_PX_PER_SEC) * 1000;
-
-		return el.animate(
-			{ left: `${-el.offsetWidth}px` },
-			{ duration: durationMs, easing: "linear" },
-		);
 	};
 
 	const createCommentElement = (
@@ -133,7 +150,7 @@ export const injectComment = async (
 	) => {
 		const availableHeightPx = screenHeightPx - FOOTER_HEIGHT_PX;
 		const scrollTopPx = window.pageYOffset;
-		const { topPx, laneIndex } = pickLanePlacement(
+		const { topPx, laneIndex } = decideLanePlacement(
 			fontSizePx,
 			availableHeightPx,
 			scrollTopPx,
@@ -155,7 +172,13 @@ export const injectComment = async (
 		screenWidthPx: number,
 		parent: HTMLElement,
 	) => {
-		const animation = animateComment(el, screenWidthPx);
+		const travelDistancePx = screenWidthPx + el.offsetWidth;
+		const durationMs = (travelDistancePx / SPEED_PX_PER_SEC) * 1000;
+
+		const animation = el.animate(
+			{ left: `${-el.offsetWidth}px` },
+			{ duration: durationMs, easing: "linear" },
+		);
 
 		// アニメーション完了時に DOM 除去と storage 削除を行う。
 		// `ready` (アニメ開始時) ではなく `finish` で削除することで、
@@ -169,7 +192,9 @@ export const injectComment = async (
 		};
 	};
 
-	// --- main flow ---
+	// ============================================================
+	// 4. main flow
+	// ============================================================
 	const screenHeightPx = window.innerHeight;
 	const screenWidthPx = window.innerWidth;
 

--- a/src/shared/commentLogic.test.ts
+++ b/src/shared/commentLogic.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+	BASE_FONT_SIZE_RATIO,
+	computeLaneLayout,
+	pickFreeLane,
+	resolveColor,
+	resolveFontSizePx,
+	usernameToColor,
+} from "./commentLogic";
+
+describe("resolveFontSizePx", () => {
+	const coefficients = { XS: 0.25, S: 0.5, M: 1, L: 2, XL: 4 };
+
+	it("returns screenHeight * BASE_RATIO * coefficient", () => {
+		expect(resolveFontSizePx(1000, "M", coefficients, coefficients.L)).toBe(
+			1000 * BASE_FONT_SIZE_RATIO * 1,
+		);
+		expect(resolveFontSizePx(1000, "XL", coefficients, coefficients.L)).toBe(
+			1000 * BASE_FONT_SIZE_RATIO * 4,
+		);
+	});
+
+	it("falls back to defaultCoefficient when key is unknown", () => {
+		expect(
+			resolveFontSizePx(1000, "unknown", coefficients, coefficients.L),
+		).toBe(1000 * BASE_FONT_SIZE_RATIO * 2);
+	});
+});
+
+describe("usernameToColor", () => {
+	it("is stable for the same username", () => {
+		expect(usernameToColor("alice")).toBe(usernameToColor("alice"));
+	});
+
+	it("produces a valid hsl() string in the expected shape", () => {
+		const color = usernameToColor("bob");
+		expect(color).toMatch(/^hsl\(\d{1,3}, 70%, 60%\)$/);
+	});
+
+	it("maps empty string to a deterministic color", () => {
+		expect(usernameToColor("")).toBe("hsl(0, 70%, 60%)");
+	});
+});
+
+describe("resolveColor", () => {
+	it("prefers usernameToColor when author is present", () => {
+		const color = resolveColor("alice", "red", "green");
+		expect(color).toBe(usernameToColor("alice"));
+	});
+
+	it("returns storedColor when author is empty", () => {
+		expect(resolveColor("", "red", "green")).toBe("red");
+	});
+
+	it("returns defaultColor when both author and storedColor are empty", () => {
+		expect(resolveColor("", undefined, "green")).toBe("green");
+		expect(resolveColor("", "", "green")).toBe("green");
+	});
+});
+
+describe("pickFreeLane", () => {
+	it("returns null when all lanes are occupied", () => {
+		expect(pickFreeLane(3, new Set([0, 1, 2]))).toBeNull();
+	});
+
+	it("returns the only free lane when others are occupied", () => {
+		// random を 0 固定にして先頭候補を選ぶ
+		expect(pickFreeLane(3, new Set([0, 2]), () => 0)).toBe(1);
+	});
+
+	it("returns 0 when no lane is occupied and random returns 0", () => {
+		expect(pickFreeLane(3, new Set(), () => 0)).toBe(0);
+	});
+
+	it("uses random to pick among multiple free lanes", () => {
+		// freeLanes = [0, 1, 2], random=0.99 → 末尾候補 (index 2) を選ぶ
+		expect(pickFreeLane(3, new Set(), () => 0.99)).toBe(2);
+	});
+});
+
+describe("computeLaneLayout", () => {
+	it("returns laneHeight = fontSize * (1 + LANE_GAP_RATIO)", () => {
+		const { laneHeightPx } = computeLaneLayout(10, 1000);
+		expect(laneHeightPx).toBeCloseTo(12);
+	});
+
+	it("returns laneCount = floor(availableHeight / laneHeight), min 1", () => {
+		expect(computeLaneLayout(10, 100).laneCount).toBe(8); // 100 / 12 = 8.33 → 8
+		expect(computeLaneLayout(10, 5).laneCount).toBe(1); // 5 / 12 < 1 → 1 (clamp)
+	});
+});

--- a/src/shared/commentLogic.ts
+++ b/src/shared/commentLogic.ts
@@ -1,0 +1,67 @@
+// injectComment から切り出した純粋ロジック。
+// DOM / chrome API に依存しないため、vitest で単体テスト可能。
+//
+// NOTE: このモジュールは background (bundled) からも参照されるが、
+//       executeScript で注入される側 (injectComment) からは
+//       トップレベル import できない。呼び出し側で同等の実装を再現するか、
+//       args 経由で計算結果のみを渡す設計とする。
+
+// 画面高さに対するフォントサイズ基準
+export const BASE_FONT_SIZE_RATIO = 0.05;
+// フォントサイズに対するレーン間隔
+const LANE_GAP_RATIO = 0.2;
+
+export const resolveFontSizePx = (
+	screenHeightPx: number,
+	key: string,
+	coefficients: Record<string, number>,
+	defaultCoefficient: number,
+): number => {
+	const coefficient = coefficients[key] ?? defaultCoefficient;
+	return screenHeightPx * BASE_FONT_SIZE_RATIO * coefficient;
+};
+
+// ユーザー名を HSL の hue に変換して、投稿者ごとに安定した色を割り当てる。
+// 見た目の色分けのための簡易ハッシュで厳密な一様分布は狙っていない。
+export const usernameToColor = (username: string): string => {
+	let hash = 0;
+	for (let i = 0; i < username.length; i++) {
+		hash = username.charCodeAt(i) + ((hash << 5) - hash);
+		hash = hash & hash;
+	}
+	const hue = Math.abs(hash) % 360;
+	return `hsl(${hue}, 70%, 60%)`;
+};
+
+export const resolveColor = (
+	author: string,
+	storedColor: string | undefined,
+	defaultColor: string,
+): string => {
+	if (author) return usernameToColor(author);
+	return storedColor || defaultColor;
+};
+
+// 占有レーン集合を受け取り、空きがあればランダムに 1 つ選ぶ。
+// 全レーン占有時は null を返し、呼び出し側でフォールバックする。
+export const pickFreeLane = (
+	laneCount: number,
+	occupiedLanes: ReadonlySet<number>,
+	random: () => number = Math.random,
+): number | null => {
+	const freeLanes: number[] = [];
+	for (let i = 0; i < laneCount; i++) {
+		if (!occupiedLanes.has(i)) freeLanes.push(i);
+	}
+	if (freeLanes.length === 0) return null;
+	return freeLanes[Math.floor(random() * freeLanes.length)];
+};
+
+export const computeLaneLayout = (
+	fontSizePx: number,
+	availableHeightPx: number,
+): { laneHeightPx: number; laneCount: number } => {
+	const laneHeightPx = fontSizePx + fontSizePx * LANE_GAP_RATIO;
+	const laneCount = Math.max(1, Math.floor(availableHeightPx / laneHeightPx));
+	return { laneHeightPx, laneCount };
+};


### PR DESCRIPTION
## Summary

- `shared/commentLogic.ts` を新設し、`resolveFontSizePx` / `usernameToColor` / `resolveColor` / `pickFreeLane` / `computeLaneLayout` を純粋関数として切り出し
- `shared/commentLogic.test.ts` で単体テストを追加 (14 テスト)
- `injectComment.ts` を「定数 / pure logic / DOM / main flow」の 4 セクションに再整理
- レーン計算の副作用 (`readOccupiedLanes`) と純粋ロジック (`pickFreeLane` / `computeLaneLayout`) を分離

executeScript 制約によりロジック本体は inline 実装のままだが、同等ロジックを shared 側にも実装することで vitest でカバーできるようにする。

closes #61

## Base

このブランチは #67 をベースにしているため、#67 のマージ後に base が main に切り替わる。

## Test plan

- [x] `pnpm build` が通る
- [x] `pnpm check` が通る
- [x] `pnpm test:run` が通る (24 テスト)
- [x] `pnpm knip` が未使用 export を検出しない
- [ ] 実機: コメントが正しく流れ、レーンが適切に空くこと