### PR TITLE
refactor: legacyChat の差分検出を signature ベースに軽量化 (#65)

### DIFF
--- a/src/contentScripts/extractors/legacyChat.ts
+++ b/src/contentScripts/extractors/legacyChat.ts
@@ -38,24 +38,29 @@ const extractAuthorFromMessageNode = (
 
 // スレッド要素の差分を検出しつつ最新メッセージを返す抽出器を生成する factory。
 // 旧チャットと旧ポップアップは構造が似ているためセレクタ差し替えで共通化できる。
+//
+// 差分検出は「メッセージ要素数 + 末尾 message node の innerHTML」で判定する。
+// 以前は isEqualNode + cloneNode(true) でツリーを丸ごとディープ比較・コピーして
+// いたため、長時間ミーティングで DOM が肥大化すると O(n) の負荷がかかっていた。
 const createThreadExtractor = (
 	getThread: () => Element | null,
 	messageSelector: string,
 ): CommentExtractor => {
-	let lastSnapshot: Node | undefined;
+	let lastSignature: string | undefined;
 
 	return (): ExtractedComment | undefined => {
 		const thread = getThread();
-		if (!thread || thread.isEqualNode(lastSnapshot ?? null)) return;
-
-		lastSnapshot = thread.cloneNode(true);
+		if (!thread) return;
 
 		const messageNodes = thread.querySelectorAll(messageSelector);
 		if (messageNodes.length === 0) return;
 
 		const messageNode = messageNodes[messageNodes.length - 1];
-		const author = extractAuthorFromMessageNode(messageNode);
+		const signature = `${messageNodes.length}:${messageNode.innerHTML}`;
+		if (signature === lastSignature) return;
+		lastSignature = signature;
 
+		const author = extractAuthorFromMessageNode(messageNode);
 		return { message: messageNode.innerHTML, author };
 	};
 };


### PR DESCRIPTION
## Summary

- `createThreadExtractor` の差分検出を `isEqualNode` + `cloneNode(true)` から、
  「メッセージ要素数 + 末尾 message node の innerHTML」を連結した signature 文字列比較に置き換え
- DOM ツリーのディープ比較・コピーを廃止し、長時間ミーティング時の負荷を軽減

closes #65

## Test plan

- [x] `pnpm build` が通る
- [x] `pnpm check` が通る
- [x] `pnpm test:run` が通る
- [x] `pnpm knip` が未使用 export を検出しない
- [ ] 実機 (旧チャット UI): 同一メッセージが重複取得されないこと / 新規メッセージが拾えること